### PR TITLE
Mark passed show dates closed

### DIFF
--- a/index.html
+++ b/index.html
@@ -699,6 +699,21 @@
           </div>
         </div>
       </div>
+      <script>
+        document.addEventListener('DOMContentLoaded', () => {
+          const now = new Date();
+          document.querySelectorAll('#show-schedule tbody tr').forEach(row => {
+            const dateCell = row.querySelector('td');
+            if (!dateCell) return;
+            const perfDate = new Date(dateCell.textContent.trim() + ' 2025');
+            if (perfDate < now) {
+              row.classList.add('line-through', 'opacity-50');
+              const ticketLink = row.querySelector('a');
+              if (ticketLink) ticketLink.textContent = 'Closed';
+            }
+          });
+        });
+      </script>
     </section>
   </section>
 


### PR DESCRIPTION
## Summary
- add a short script after the schedule table to mark past show dates as closed

## Testing
- `npm test`
- `python3 validate.py`


------
https://chatgpt.com/codex/tasks/task_e_68579fc81974832a8452c80d325fba15