### PR TITLE
Fix table responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -620,7 +620,7 @@
 
         <div class="overflow-x-auto w-full max-w-full">
           <div class="w-full max-w-5xl mx-auto bg-black bg-opacity-70 p-8 rounded-3xl ornamental-border shadow-xl">
-            <table class="min-w-[600px] md:min-w-full table-auto text-yellow-100 text-sm sm:text-base text-center">
+            <table class="w-full table-auto text-yellow-100 text-sm sm:text-base text-center stackable-table">
               <thead>
                 <tr>
                   <th class="px-4 py-2">Date</th>
@@ -632,65 +632,65 @@
               </thead>
               <tbody>
                 <tr>
-                  <td class="px-4 py-2">Sun, June 8</td>
-                  <td class="px-4 py-2">Preview Night</td>
-                  <td class="px-4 py-2">9:45 PM</td>
-                  <td class="px-4 py-2">Zephyr Theatre</td>
-                  <td class="px-4 py-2">
+                  <td class="px-4 py-2" data-label="Date">Sun, June 8</td>
+                  <td class="px-4 py-2" data-label="Event">Preview Night</td>
+                  <td class="px-4 py-2" data-label="Time">9:45 PM</td>
+                  <td class="px-4 py-2" data-label="Venue">Zephyr Theatre</td>
+                  <td class="px-4 py-2" data-label="Tickets">
                     <a href="https://www.hollywoodfringe.org/projects/11553?embed=false&performance_id=27027&tab=performance" class="text-blue-400 hover:underline" target="_blank">Get Tickets</a>
                   </td>
                 </tr>
                 <tr>
-                  <td class="px-4 py-2">Fri, June 13</td>
-                  <td class="px-4 py-2">Performance 1</td>
-                  <td class="px-4 py-2">4:30 PM</td>
-                  <td class="px-4 py-2">Zephyr Theatre</td>
-                  <td class="px-4 py-2">
+                  <td class="px-4 py-2" data-label="Date">Fri, June 13</td>
+                  <td class="px-4 py-2" data-label="Event">Performance 1</td>
+                  <td class="px-4 py-2" data-label="Time">4:30 PM</td>
+                  <td class="px-4 py-2" data-label="Venue">Zephyr Theatre</td>
+                  <td class="px-4 py-2" data-label="Tickets">
                     <a href="https://www.hollywoodfringe.org/projects/11553?embed=false&performance_id=27028&tab=performance" class="text-blue-400 hover:underline" target="_blank">Get Tickets</a>
                   </td>
                 </tr>
                 <tr>
-                  <td class="px-4 py-2">Sun, June 15</td>
-                  <td class="px-4 py-2">Performance 2</td>
-                  <td class="px-4 py-2">7:45 PM</td>
-                  <td class="px-4 py-2">Zephyr Theatre</td>
-                  <td class="px-4 py-2">
+                  <td class="px-4 py-2" data-label="Date">Sun, June 15</td>
+                  <td class="px-4 py-2" data-label="Event">Performance 2</td>
+                  <td class="px-4 py-2" data-label="Time">7:45 PM</td>
+                  <td class="px-4 py-2" data-label="Venue">Zephyr Theatre</td>
+                  <td class="px-4 py-2" data-label="Tickets">
                     <a href="https://www.hollywoodfringe.org/projects/11553?embed=false&performance_id=27029&tab=performance" class="text-blue-400 hover:underline" target="_blank">Get Tickets</a>
                   </td>
                 </tr>
                 <tr>
-                  <td class="px-4 py-2">Wed, June 18</td>
-                  <td class="px-4 py-2">Performance 3</td>
-                  <td class="px-4 py-2">8:15 PM</td>
-                  <td class="px-4 py-2">Zephyr Theatre</td>
-                  <td class="px-4 py-2">
+                  <td class="px-4 py-2" data-label="Date">Wed, June 18</td>
+                  <td class="px-4 py-2" data-label="Event">Performance 3</td>
+                  <td class="px-4 py-2" data-label="Time">8:15 PM</td>
+                  <td class="px-4 py-2" data-label="Venue">Zephyr Theatre</td>
+                  <td class="px-4 py-2" data-label="Tickets">
                     <a href="https://www.hollywoodfringe.org/projects/11553?embed=false&performance_id=28324&tab=performance" class="text-blue-400 hover:underline" target="_blank">Get Tickets</a>
                   </td>
                 </tr>
                 <tr>
-                  <td class="px-4 py-2">Thu, June 19</td>
-                  <td class="px-4 py-2">Performance 4</td>
-                  <td class="px-4 py-2">5:00 PM</td>
-                  <td class="px-4 py-2">Zephyr Theatre</td>
-                  <td class="px-4 py-2">
+                  <td class="px-4 py-2" data-label="Date">Thu, June 19</td>
+                  <td class="px-4 py-2" data-label="Event">Performance 4</td>
+                  <td class="px-4 py-2" data-label="Time">5:00 PM</td>
+                  <td class="px-4 py-2" data-label="Venue">Zephyr Theatre</td>
+                  <td class="px-4 py-2" data-label="Tickets">
                     <a href="https://www.hollywoodfringe.org/projects/11553?embed=false&performance_id=27030&tab=performance" class="text-blue-400 hover:underline" target="_blank">Get Tickets</a>
                   </td>
                 </tr>
                 <tr>
-                  <td class="px-4 py-2">Thu, June 25</td>
-                  <td class="px-4 py-2">Performance 5</td>
-                  <td class="px-4 py-2">7:00 PM</td>
-                  <td class="px-4 py-2">Zephyr Theatre</td>
-                  <td class="px-4 py-2">
+                  <td class="px-4 py-2" data-label="Date">Thu, June 25</td>
+                  <td class="px-4 py-2" data-label="Event">Performance 5</td>
+                  <td class="px-4 py-2" data-label="Time">7:00 PM</td>
+                  <td class="px-4 py-2" data-label="Venue">Zephyr Theatre</td>
+                  <td class="px-4 py-2" data-label="Tickets">
                     <a href="https://www.hollywoodfringe.org/projects/11553?embed=false&performance_id=28471&tab=performance" class="text-blue-400 hover:underline" target="_blank">Get Tickets</a>
                   </td>
                 </tr>
                 <tr>
-                  <td class="px-4 py-2">Sat, June 28</td>
-                  <td class="px-4 py-2">Closing Night</td>
-                  <td class="px-4 py-2">10:30 PM</td>
-                  <td class="px-4 py-2">Zephyr Theatre</td>
-                  <td class="px-4 py-2">
+                  <td class="px-4 py-2" data-label="Date">Sat, June 28</td>
+                  <td class="px-4 py-2" data-label="Event">Closing Night</td>
+                  <td class="px-4 py-2" data-label="Time">10:30 PM</td>
+                  <td class="px-4 py-2" data-label="Venue">Zephyr Theatre</td>
+                  <td class="px-4 py-2" data-label="Tickets">
                     <a href="https://www.hollywoodfringe.org/projects/11553?embed=false&performance_id=27031&tab=performance" class="text-blue-400 hover:underline" target="_blank">Get Tickets</a>
                   </td>
                 </tr>

--- a/style.css
+++ b/style.css
@@ -38,4 +38,24 @@ p {
     #countdown-timer {
         font-size: 1.25rem;
     }
+
+    /* Stack schedule table cells vertically */
+    .stackable-table thead {
+        display: none;
+    }
+    .stackable-table tr {
+        display: block;
+        margin-bottom: 1rem;
+    }
+    .stackable-table td {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+    }
+    .stackable-table td::before {
+        content: attr(data-label);
+        font-weight: 600;
+    }
 }


### PR DESCRIPTION
## Summary
- allow schedule table to shrink below 600px
- stack schedule table cells vertically on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68579fcd8764832aaf72ba0242c2ffcd